### PR TITLE
온보딩 메타데이터 조회 및 제출 API 구현 완료

### DIFF
--- a/src/main/java/com/archiveat/server/domain/explore/entity/Category.java
+++ b/src/main/java/com/archiveat/server/domain/explore/entity/Category.java
@@ -1,14 +1,23 @@
 package com.archiveat.server.domain.explore.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "categories")
 public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name; // 경제, IT ...
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
+    private List<Topic> topics = new ArrayList<>(); // 초기화를 통해 NullPointerException 방지
 }

--- a/src/main/java/com/archiveat/server/domain/explore/entity/Topic.java
+++ b/src/main/java/com/archiveat/server/domain/explore/entity/Topic.java
@@ -1,10 +1,13 @@
 package com.archiveat.server.domain.explore.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "topics")
 public class Topic {
     @Id

--- a/src/main/java/com/archiveat/server/domain/explore/entity/UserTopic.java
+++ b/src/main/java/com/archiveat/server/domain/explore/entity/UserTopic.java
@@ -2,10 +2,13 @@ package com.archiveat.server.domain.explore.entity;
 
 import com.archiveat.server.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA를 위한 기본 생성자
 @Table(name = "user_topics")
 public class UserTopic {
     @Id
@@ -19,4 +22,14 @@ public class UserTopic {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "topic_id")
     private Topic topic;
+
+    /**
+     * 서비스 레이어에서 UserTopic 객체를 생성하기 위한 생성자입니다.
+     * @param user 관심사를 등록하는 사용자
+     * @param topic 사용자가 선택한 관심 토픽
+     */
+    public UserTopic(User user, Topic topic) {
+        this.user = user;
+        this.topic = topic;
+    }
 }

--- a/src/main/java/com/archiveat/server/domain/explore/repository/SampleCategoryRepository.java
+++ b/src/main/java/com/archiveat/server/domain/explore/repository/SampleCategoryRepository.java
@@ -1,0 +1,10 @@
+package com.archiveat.server.domain.explore.repository;
+
+import com.archiveat.server.domain.explore.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SampleCategoryRepository extends JpaRepository<Category, Long> {
+    // todo: 혹시 겹칠까봐 임시로 Sample이라고 만듦. 이거 지금 온보딩 메타데이터 조회쪽에 사용중
+}

--- a/src/main/java/com/archiveat/server/domain/explore/repository/TopicRepository.java
+++ b/src/main/java/com/archiveat/server/domain/explore/repository/TopicRepository.java
@@ -1,0 +1,9 @@
+package com.archiveat.server.domain.explore.repository;
+
+import com.archiveat.server.domain.explore.entity.Topic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TopicRepository extends JpaRepository<Topic, Long> {
+}

--- a/src/main/java/com/archiveat/server/domain/explore/repository/UserTopicRepository.java
+++ b/src/main/java/com/archiveat/server/domain/explore/repository/UserTopicRepository.java
@@ -1,0 +1,11 @@
+package com.archiveat.server.domain.explore.repository;
+
+import com.archiveat.server.domain.explore.entity.UserTopic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserTopicRepository extends JpaRepository<UserTopic, Long> {
+    // 특정 유저의 기존 관심사를 한 번에 삭제하기 위한 쿼리 메서드입니다.
+    void deleteAllByUserId(Long userId);
+}

--- a/src/main/java/com/archiveat/server/domain/user/controller/OnboardingController.java
+++ b/src/main/java/com/archiveat/server/domain/user/controller/OnboardingController.java
@@ -1,8 +1,12 @@
 package com.archiveat.server.domain.user.controller;
 
 import com.archiveat.server.domain.user.dto.request.NicknameRequest;
-import com.archiveat.server.domain.user.service.UserService;
+import com.archiveat.server.domain.user.dto.request.OnboardingInfoRequest;
+import com.archiveat.server.domain.user.dto.response.NicknameResponse;
+import com.archiveat.server.domain.user.dto.response.OnboardingMetadataResponse;
+import com.archiveat.server.domain.user.service.OnboardingService;
 import com.archiveat.server.global.common.response.ApiResponse;
+import com.archiveat.server.global.common.response.SuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,14 +16,40 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/user")
 public class OnboardingController {
-    private final UserService userService;
+    private final OnboardingService onboardingService;
 
     @PostMapping("/nickname")
     public ApiResponse<Void> editNickname(
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody NicknameRequest request
-    ){
-        userService.editNickname(userId, request.getNickname());
+    ) {
+        onboardingService.editNickname(userId, request.getNickname());
+
+        return ApiResponse.ok(null);
+    }
+
+    @GetMapping("/nickname")
+    public ApiResponse<NicknameResponse> nickname(
+            @AuthenticationPrincipal Long userId
+    ) {
+        NicknameResponse nicknameResponse = onboardingService.getNickname(userId);
+
+        return ApiResponse.ok(SuccessCode.SUCCESS, nicknameResponse);
+    }
+
+    @GetMapping("/metadata")
+    public ApiResponse<OnboardingMetadataResponse> getOnboardingMetadata() {
+        OnboardingMetadataResponse metadataResponse = onboardingService.getOnboardingMetadata();
+
+        return ApiResponse.ok(metadataResponse);
+    }
+
+    @PostMapping("/metadata")
+    public ApiResponse<Void> submitOnboardingInfo(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody OnboardingInfoRequest request
+    ) {
+        onboardingService.submitOnboardingInfo(userId, request);
 
         return ApiResponse.ok(null);
     }

--- a/src/main/java/com/archiveat/server/domain/user/dto/request/OnboardingInfoRequest.java
+++ b/src/main/java/com/archiveat/server/domain/user/dto/request/OnboardingInfoRequest.java
@@ -1,0 +1,32 @@
+package com.archiveat.server.domain.user.dto.request;
+
+import com.archiveat.server.global.common.constant.DepthType;
+import com.archiveat.server.global.common.constant.EmploymentType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record OnboardingInfoRequest(
+        @NotNull(message = "직업 군 정보는 필수입니다.")
+        EmploymentType employmentType,
+
+        @Valid
+        @NotNull(message = "시간대별 선호도 정보는 필수입니다.")
+        AvailabilityRequest availability,
+
+        @Valid
+        @NotNull(message = "관심사 정보는 필수입니다.")
+        List<CategoryInterestRequest> interests // InterestsRequest 제거하고 바로 List로 받음
+) {
+    public record AvailabilityRequest(
+            DepthType pref_morning,
+            DepthType pref_lunch,
+            DepthType pref_evening,
+            DepthType pref_bedtime
+    ) {}
+
+    public record CategoryInterestRequest(
+            @NotNull Long categoryId,
+            List<Long> topicIds
+    ) {}
+}

--- a/src/main/java/com/archiveat/server/domain/user/dto/response/NicknameResponse.java
+++ b/src/main/java/com/archiveat/server/domain/user/dto/response/NicknameResponse.java
@@ -1,0 +1,6 @@
+package com.archiveat.server.domain.user.dto.response;
+
+public record NicknameResponse(
+        String nickname
+) {
+}

--- a/src/main/java/com/archiveat/server/domain/user/dto/response/OnboardingMetadataResponse.java
+++ b/src/main/java/com/archiveat/server/domain/user/dto/response/OnboardingMetadataResponse.java
@@ -1,0 +1,20 @@
+package com.archiveat.server.domain.user.dto.response;
+
+import java.util.List;
+
+public record OnboardingMetadataResponse(
+        List<String> employmentTypes,
+        List<String> availabilityOptions,
+        List<CategoryMetadataResponse> categories
+) {
+    public record CategoryMetadataResponse(
+            Long id,
+            String name,
+            List<TopicMetadataResponse> topics
+    ) {}
+
+    public record TopicMetadataResponse(
+            Long id,
+            String name
+    ) {}
+}

--- a/src/main/java/com/archiveat/server/domain/user/entity/User.java
+++ b/src/main/java/com/archiveat/server/domain/user/entity/User.java
@@ -1,6 +1,8 @@
 package com.archiveat.server.domain.user.entity;
 
+import com.archiveat.server.domain.user.dto.request.OnboardingInfoRequest;
 import com.archiveat.server.global.common.BaseEntity;
+import com.archiveat.server.global.common.constant.DepthType;
 import com.archiveat.server.global.common.constant.EmploymentType;
 import jakarta.persistence.*;
 import lombok.*;
@@ -23,6 +25,15 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private EmploymentType employmentType;
 
+    @Enumerated(EnumType.STRING)
+    private DepthType prefMorning;
+    @Enumerated(EnumType.STRING)
+    private DepthType prefLunch;
+    @Enumerated(EnumType.STRING)
+    private DepthType prefEvening;
+    @Enumerated(EnumType.STRING)
+    private DepthType prefBedtime;
+
     private Integer commuteDurationMin;
     private LocalDateTime lastLoginAt;
 
@@ -41,5 +52,14 @@ public class User extends BaseEntity {
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateOnboardingInfo(EmploymentType employmentType,
+                                     OnboardingInfoRequest.AvailabilityRequest availability) {
+        this.employmentType = employmentType;
+        this.prefMorning = availability.pref_morning();
+        this.prefLunch = availability.pref_lunch();
+        this.prefEvening = availability.pref_evening();
+        this.prefBedtime = availability.pref_bedtime();
     }
 }

--- a/src/main/java/com/archiveat/server/domain/user/service/OnboardingService.java
+++ b/src/main/java/com/archiveat/server/domain/user/service/OnboardingService.java
@@ -1,0 +1,118 @@
+package com.archiveat.server.domain.user.service;
+
+import com.archiveat.server.domain.explore.entity.Category;
+import com.archiveat.server.domain.explore.entity.Topic;
+import com.archiveat.server.domain.explore.entity.UserTopic;
+import com.archiveat.server.domain.explore.repository.SampleCategoryRepository;
+import com.archiveat.server.domain.explore.repository.TopicRepository;
+import com.archiveat.server.domain.explore.repository.UserTopicRepository;
+import com.archiveat.server.domain.user.dto.request.OnboardingInfoRequest;
+import com.archiveat.server.domain.user.dto.response.NicknameResponse;
+import com.archiveat.server.domain.user.dto.response.OnboardingMetadataResponse;
+import com.archiveat.server.domain.user.entity.User;
+import com.archiveat.server.domain.user.repository.UserRepository;
+import com.archiveat.server.global.common.constant.AvailabilityType;
+import com.archiveat.server.global.common.constant.EmploymentType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@RequiredArgsConstructor
+@Service
+public class OnboardingService {
+    private final UserRepository userRepository;
+    private final SampleCategoryRepository categoryRepository;
+    private final UserTopicRepository userTopicRepository; // 추가
+    private final TopicRepository topicRepository;
+
+    // 닉네임 수정
+    @Transactional
+    public void editNickname(Long userId, String newNickname) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("User not found. id=" + userId));
+
+        user.updateNickname(newNickname);
+    }
+
+    // 닉네임 조회
+    @Transactional(readOnly = true)
+    public NicknameResponse getNickname(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("User not found. id=" + userId));
+
+        return new NicknameResponse(user.getNickname());
+    }
+
+    // 온보딩 메타데이터 조회
+    @Transactional(readOnly = true)
+    public OnboardingMetadataResponse getOnboardingMetadata() {
+        // 1. 직업 군 및 시간대 옵션을 Enum에서 추출하여 String 리스트로 변환
+        List<String> employmentTypes = Arrays.stream(EmploymentType.values())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+
+        List<String> availabilityOptions = Arrays.stream(AvailabilityType.values())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+
+        // 2. DB에서 모든 카테고리와 연관된 토픽 정보를 조회
+        List<Category> categories = categoryRepository.findAll();
+
+        // 3. Entity 리스트를 Response DTO 구조로 매핑
+        List<OnboardingMetadataResponse.CategoryMetadataResponse> categoryMetadata = categories.stream()
+                .map(category -> new OnboardingMetadataResponse.CategoryMetadataResponse(
+                        category.getId(),
+                        category.getName(),
+                        category.getTopics().stream() // Category-Topic은 OneToMany 관계라고 가정합니다.
+                                .map(topic -> new OnboardingMetadataResponse.TopicMetadataResponse(
+                                        topic.getId(),
+                                        topic.getName()
+                                ))
+                                .collect(Collectors.toList())
+                ))
+                .collect(Collectors.toList());
+
+        return new OnboardingMetadataResponse(
+                employmentTypes,
+                availabilityOptions,
+                categoryMetadata
+        );
+    }
+
+    @Transactional
+    public void submitOnboardingInfo(Long userId, OnboardingInfoRequest request) {
+        // 1. 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("User not found. id=" + userId));
+
+        // 2. 유저 기본 정보(직업군, 시간대 선호도) 업데이트
+        user.updateOnboardingInfo(request.employmentType(), request.availability());
+
+        // 3. 기존 관심사(UserTopic) 삭제 (Delete All)
+        userTopicRepository.deleteAllByUserId(userId);
+
+        // 4. 새로운 관심사 저장 (Insert All)
+        // 모든 카테고리의 topicId를 하나의 리스트로 모읍니다.
+        List<Long> allTopicIds = request.interests().stream()
+                .flatMap(interest -> interest.topicIds().stream())
+                .distinct()
+                .collect(Collectors.toList());
+
+        // Topic 엔티티들을 조회하여 UserTopic으로 변환 후 저장
+        List<UserTopic> newUserTopics = allTopicIds.stream()
+                .map(topicId -> {
+                    Topic topic = topicRepository.findById(topicId)
+                            .orElseThrow(() -> new IllegalStateException("Topic not found. id=" + topicId));
+                    return new UserTopic(user, topic);
+                })
+                .collect(Collectors.toList());
+
+        userTopicRepository.saveAll(newUserTopics);
+    }
+
+}

--- a/src/main/java/com/archiveat/server/domain/user/service/UserService.java
+++ b/src/main/java/com/archiveat/server/domain/user/service/UserService.java
@@ -3,16 +3,12 @@ package com.archiveat.server.domain.user.service;
 import com.archiveat.server.domain.user.dto.response.LoginResponse;
 import com.archiveat.server.domain.user.entity.User;
 import com.archiveat.server.domain.user.repository.UserRepository;
-import com.archiveat.server.global.common.response.ApiResponse;
-import com.archiveat.server.global.common.response.SuccessCode;
 import com.archiveat.server.global.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.security.auth.login.AccountNotFoundException;
-import java.util.Optional;
 
 //final 이거나 @NonNull 이 붙은 필드만 파라미터로 받는 생성자를 자동 생성
 @RequiredArgsConstructor
@@ -57,16 +53,6 @@ public class UserService {
 
         return new LoginResponse(accessToken, GRANT_TYPE);
     }
-
-    /**
-     * 닉네임 수정
-     */
-    @Transactional
-    public void editNickname(Long userId, String newNickname) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalStateException("User not found. id=" + userId));
-
-        user.updateNickname(newNickname);
-    }
+    
 
 }

--- a/src/main/java/com/archiveat/server/global/common/constant/AvailabilityType.java
+++ b/src/main/java/com/archiveat/server/global/common/constant/AvailabilityType.java
@@ -1,0 +1,15 @@
+package com.archiveat.server.global.common.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AvailabilityType {
+    MORNING("아침"),
+    LUNCHTIME("점심"),
+    EVENING("저녁"),
+    BEDTIME("자기 전");
+
+    private final String description;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 온보딩 프로세스 추가: 이제 사용자는 닉네임을 설정 및 관리할 수 있습니다. 고용 형태를 선택하고, 아침·점심·저녁·자기 전의 시간대별 가용성을 설정한 후, 카테고리별 관심 주제를 선택하여 온보딩 정보를 제출할 수 있습니다. 또한 사용 가능한 고용 형태, 시간대 옵션, 카테고리 및 주제 목록을 조회하는 메타데이터 기능이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->