### PR TITLE
fix: naver newsletter count up!

### DIFF
--- a/src/main/java/com/archiveat/server/domain/newsletter/service/NewsletterService.java
+++ b/src/main/java/com/archiveat/server/domain/newsletter/service/NewsletterService.java
@@ -479,11 +479,11 @@ public class NewsletterService {
                         newsletter.getCategory());
                 userNewsletter.updateLabelComponents(perspectiveType, depthType);
 
-                // [Safeguard] 유저가 이미 분류를 확정한 경우(isConfirmed=true)에는 덮어쓰지 않음
-                if (!userNewsletter.isConfirmed()) {
-                    if (category != null && topic != null) {
-                        userNewsletter.updateCategoryAndTopic(category, topic);
-                    }
+                // topic이 아직 미할당이면 무조건 세팅
+                // (유저가 읽기(isConfirmed=true) 후 비동기 처리가 완료되는 경우 대응)
+                // 유저가 직접 분류를 변경한 경우(updateClassification)에는 topic이 이미 존재하므로 덮어쓰지 않음
+                if (category != null && topic != null && userNewsletter.getTopic() == null) {
+                    userNewsletter.updateCategoryAndTopic(category, topic);
                 }
             }
         });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 픽스

* 뉴스레터 라벨 및 카테고리 할당 로직을 개선했습니다. 토픽이 아직 설정되지 않은 사용자의 경우 카테고리와 토픽이 올바르게 할당되도록 수정되었습니다. 이제 비동기 처리 시나리오도 안정적으로 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->