### PR TITLE
fix: Let's make it 401 Unauthorized

### DIFF
--- a/src/main/java/com/archiveat/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/archiveat/server/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.archiveat.server.global.config;
 
+import com.archiveat.server.global.jwt.JwtAuthenticationEntryPoint;
 import com.archiveat.server.global.jwt.JwtAuthenticationFilter;
 import com.archiveat.server.global.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -25,23 +26,28 @@ import org.springframework.http.HttpMethod;
 public class SecurityConfig {
 
         private final JwtUtil jwtUtil;
+        private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
         @Bean
         public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
                 return http
                                 .csrf(csrf -> csrf.disable()) // REST API면 보통 disable
-                                // 이전: SecurityFilterChain에 CORS 설정 없음
-                                // .cors(...) 없음
                                 .cors(Customizer.withDefaults())
                                 .sessionManagement(session -> session
                                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                                 .formLogin(form -> form.disable()) // 기본 /login 페이지 끄기
                                 .httpBasic(basic -> basic.disable()) // Basic 인증 요구 끄기
+                                .exceptionHandling(exception -> exception
+                                                .authenticationEntryPoint(jwtAuthenticationEntryPoint))
                                 .authorizeHttpRequests(auth -> auth
+                                                // 공개 API
+                                                .requestMatchers("/auth/**").permitAll()
+                                                .requestMatchers("/archiveat-docs/**", "/v3/api-docs/**",
+                                                                "/swagger-ui/**", "/swagger-resources/**")
+                                                .permitAll()
                                                 .requestMatchers(HttpMethod.GET, "/user/metadata").permitAll()
-                                                .requestMatchers("/user/**").authenticated() // 온보딩 관련 /user 경로는 인증 필요
-                                                .anyRequest().permitAll() // 일단 전체 오픈(개발용)
-                                )
+                                                // 나머지 전부 인증 필수
+                                                .anyRequest().authenticated())
                                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil),
                                                 UsernamePasswordAuthenticationFilter.class)
                                 .build();

--- a/src/main/java/com/archiveat/server/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/archiveat/server/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,38 @@
+package com.archiveat.server.global.jwt;
+
+import com.archiveat.server.global.common.response.ApiResponse;
+import com.archiveat.server.global.common.response.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 인증 실패 시 401 Unauthorized + JSON 에러 응답을 반환하는 EntryPoint.
+ * Spring Security 기본 동작(403 Forbidden)을 대체합니다.
+ */
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
+    @Override
+    public void commence(HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException) throws IOException {
+
+        ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<?> body = ApiResponse.fail(errorCode);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/archiveat/server/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/archiveat/server/global/jwt/JwtAuthenticationFilter.java
@@ -36,16 +36,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 // 4. Spring Security가 인식할 수 있는 인증 객체를 생성합니다.
                 // 현재는 권한 정보가 없으므로 빈 리스트를 전달합니다.
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId,
+                        null, Collections.emptyList());
 
                 // 5. 서버 내부의 보안 저장소(SecurityContext)에 이 유저가 인증되었음을 기록합니다.
                 // 이후 컨트롤러에서 이 정보를 꺼내 쓸 수 있게 됩니다.
                 SecurityContextHolder.getContext().setAuthentication(authentication);
 
             } catch (Exception e) {
-                // 토큰이 만료되었거나 변조된 경우 context에 인증 정보를 등록하지 않습니다.
-                // 이 경우 이후 SecurityConfig 설정에 따라 접근이 거부됩니다.
+                // 토큰이 만료되었거나 변조된 경우 SecurityContext를 비워서
+                // 이후 .authenticated() 규칙에서 JwtAuthenticationEntryPoint가 401을 반환하게 합니다.
+                SecurityContextHolder.clearContext();
             }
         }
 

--- a/src/test/java/com/archiveat/server/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/archiveat/server/global/config/SecurityConfigTest.java
@@ -1,0 +1,166 @@
+package com.archiveat.server.global.config;
+
+import com.archiveat.server.domain.explore.controller.ExploreController;
+import com.archiveat.server.domain.explore.service.ExploreService;
+import com.archiveat.server.domain.home.controller.HomeController;
+import com.archiveat.server.domain.home.service.HomeService;
+import com.archiveat.server.domain.user.controller.OnboardingController;
+import com.archiveat.server.domain.user.service.OnboardingService;
+import com.archiveat.server.global.jwt.JwtAuthenticationEntryPoint;
+import com.archiveat.server.global.jwt.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Spring Security 인증 정책 테스트.
+ *
+ * 검증 항목:
+ * - 보호 API: 토큰 없으면 401 + JSON 에러 응답
+ * - 보호 API: 유효 토큰이면 200 (인증 통과)
+ * - 보호 API: 만료/변조 토큰이면 401
+ * - 공개 API: 토큰 없이 접근 가능
+ */
+@WebMvcTest({ HomeController.class, ExploreController.class, OnboardingController.class })
+@Import({ JwtUtil.class, SecurityConfig.class, JwtAuthenticationEntryPoint.class })
+class SecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    // 컨트롤러가 의존하는 서비스 Mock
+    @MockitoBean
+    private HomeService homeService;
+    @MockitoBean
+    private ExploreService exploreService;
+    @MockitoBean
+    private OnboardingService onboardingService;
+
+    // ── 보호 API: 토큰 없음 → 401 ──────────────────────
+
+    @Nested
+    @DisplayName("보호 API - 토큰 없음 → 401 Unauthorized")
+    class ProtectedEndpointsWithoutToken {
+
+        @Test
+        @DisplayName("GET /home → 401 + JSON 에러 응답")
+        void home_withoutToken_returns401() throws Exception {
+            mockMvc.perform(get("/home"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(content().contentTypeCompatibleWith("application/json"))
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.statusCode").value(40100))
+                    .andExpect(jsonPath("$.message").value("인증에 실패했습니다."));
+        }
+
+        @Test
+        @DisplayName("GET /explore → 401")
+        void explore_withoutToken_returns401() throws Exception {
+            mockMvc.perform(get("/explore"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.statusCode").value(40100));
+        }
+
+        @Test
+        @DisplayName("GET /user/nickname → 401 (기존 403에서 변경)")
+        void userNickname_withoutToken_returns401() throws Exception {
+            mockMvc.perform(get("/user/nickname"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.statusCode").value(40100));
+        }
+    }
+
+    // ── 보호 API: 유효 토큰 → 200 (인증 통과) ──────────
+
+    @Nested
+    @DisplayName("보호 API - 유효 토큰 → 인증 통과")
+    class ProtectedEndpointsWithValidToken {
+
+        @Test
+        @DisplayName("GET /home + Bearer token → 200")
+        void home_withValidToken_returns200() throws Exception {
+            String token = jwtUtil.generateAccessToken(1L);
+
+            mockMvc.perform(get("/home")
+                    .header("Authorization", "Bearer " + token))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("GET /explore + Bearer token → 200")
+        void explore_withValidToken_returns200() throws Exception {
+            String token = jwtUtil.generateAccessToken(1L);
+
+            mockMvc.perform(get("/explore")
+                    .header("Authorization", "Bearer " + token))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    // ── 보호 API: 만료/변조 토큰 → 401 ─────────────────
+
+    @Nested
+    @DisplayName("보호 API - 잘못된 토큰 → 401")
+    class ProtectedEndpointsWithInvalidToken {
+
+        @Test
+        @DisplayName("GET /home + 변조된 토큰 → 401")
+        void home_withTamperedToken_returns401() throws Exception {
+            mockMvc.perform(get("/home")
+                    .header("Authorization", "Bearer invalid.token.here"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.statusCode").value(40100));
+        }
+
+        @Test
+        @DisplayName("GET /explore + 만료된 토큰 형식 → 401")
+        void explore_withExpiredToken_returns401() throws Exception {
+            // eyJ로 시작하지만 유효하지 않은 JWT
+            String fakeToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiZXhwIjoxfQ.invalid";
+
+            mockMvc.perform(get("/explore")
+                    .header("Authorization", "Bearer " + fakeToken))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.statusCode").value(40100));
+        }
+    }
+
+    // ── 공개 API: 토큰 없이 접근 가능 ──────────────────
+
+    @Nested
+    @DisplayName("공개 API - 토큰 없이 접근 가능")
+    class PublicEndpoints {
+
+        @Test
+        @DisplayName("POST /auth/login → 토큰 없이 접근 가능 (401 아닌 것만 확인)")
+        void authLogin_withoutToken_notUnauthorized() throws Exception {
+            // /auth/** 는 permitAll 이므로 401이 아닌 다른 응답(404 등)이 나와야 함
+            mockMvc.perform(post("/auth/login")
+                    .contentType("application/json")
+                    .content("{\"email\":\"test@test.com\",\"password\":\"pw\"}"))
+                    .andExpect(status().is(org.hamcrest.Matchers.not(401)));
+        }
+
+        @Test
+        @DisplayName("GET /user/metadata → 토큰 없이 접근 가능")
+        void userMetadata_withoutToken_notUnauthorized() throws Exception {
+            mockMvc.perform(get("/user/metadata"))
+                    .andExpect(status().is(org.hamcrest.Matchers.not(401)));
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JWT 기반 인증 메커니즘을 강화했습니다. 인증되지 않은 요청에 대해 명확한 401 오류 응답을 제공하도록 개선되었습니다.
  * 공개 API 엔드포인트(/auth/**, OpenAPI/Swagger, GET /user/metadata)를 허용하며, 기타 모든 엔드포인트는 인증을 필수로 요구합니다.

* **Tests**
  * 인증 및 권한 부여 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->