### PR TITLE
fix: isRead added for front-end

### DIFF
--- a/src/main/java/com/archiveat/server/domain/newsletter/dto/response/SimpleViewNewsletterResponse.java
+++ b/src/main/java/com/archiveat/server/domain/newsletter/dto/response/SimpleViewNewsletterResponse.java
@@ -3,15 +3,16 @@ package com.archiveat.server.domain.newsletter.dto.response;
 import java.util.List;
 
 public record SimpleViewNewsletterResponse(
-        Long userNewsletterId,
-        String categoryName,
-        String topicName,
-        String title,
-        String thumbnailUrl,
-        String domainName,
-        String label,
-        String memo,
-        String contentUrl,
-        String createdAt,
-        List<NewsletterSummaryBlock> newsletterSimpleSummary) {
+                Long userNewsletterId,
+                String categoryName,
+                String topicName,
+                String title,
+                String thumbnailUrl,
+                String domainName,
+                String label,
+                String memo,
+                String contentUrl,
+                String createdAt,
+                boolean isRead,
+                List<NewsletterSummaryBlock> newsletterSimpleSummary) {
 }

--- a/src/main/java/com/archiveat/server/domain/newsletter/dto/response/ViewNewsletterResponse.java
+++ b/src/main/java/com/archiveat/server/domain/newsletter/dto/response/ViewNewsletterResponse.java
@@ -3,15 +3,16 @@ package com.archiveat.server.domain.newsletter.dto.response;
 import java.util.List;
 
 public record ViewNewsletterResponse(
-        Long userNewsletterId,
-        String categoryName,
-        String topicName,
-        String title,
-        String thumbnailUrl,
-        String domainName,
-        String label,
-        String memo,
-        String contentUrl,
-        String createdAt,
-        List<NewsletterSummaryBlock> newsletterSummary) {
+                Long userNewsletterId,
+                String categoryName,
+                String topicName,
+                String title,
+                String thumbnailUrl,
+                String domainName,
+                String label,
+                String memo,
+                String contentUrl,
+                String createdAt,
+                boolean isRead,
+                List<NewsletterSummaryBlock> newsletterSummary) {
 }

--- a/src/main/java/com/archiveat/server/domain/newsletter/service/NewsletterService.java
+++ b/src/main/java/com/archiveat/server/domain/newsletter/service/NewsletterService.java
@@ -134,6 +134,7 @@ public class NewsletterService {
                                 .withZoneSameInstant(DateTimeConstant.APP_ZONE)
                                 .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
                         : null,
+                userNewsletter.isRead(),
                 summaryBlocks);
     }
 
@@ -201,6 +202,7 @@ public class NewsletterService {
                                 .withZoneSameInstant(DateTimeConstant.APP_ZONE)
                                 .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
                         : null,
+                userNewsletter.isRead(),
                 summaryBlocks);
     }
 
@@ -223,11 +225,10 @@ public class NewsletterService {
             // [Concurrency Fix] 별도 트랜잭션으로 처리
             Newsletter newsletter = newsletterSynchronizer.getOrCreatePendingNewsletter(domain, normalizedUrl);
 
-
             if (userNewsletterRepository.existsByUserAndNewsletter(user, newsletter)) {
                 throw new CustomException(ErrorCode.NEWSLETTER_ALREADY_EXISTS);
             }
-            
+
             Category category = null;
             Topic topic = null;
 
@@ -237,7 +238,6 @@ public class NewsletterService {
             }
 
             UserNewsletter userNewsletter = UserNewsletter.create(user, newsletter, category, topic, memo);
-          
 
             // 이미 분석 완료된(DONE) 뉴스레터라면 바로 라벨 계산
             if (newsletter.getLlmStatus() == LlmStatus.DONE) {
@@ -251,7 +251,8 @@ public class NewsletterService {
                 } catch (DataIntegrityViolationException e) {
                     throw new CustomException(ErrorCode.NEWSLETTER_ALREADY_EXISTS);
                 }
-                log.info("Newsletter {} is already DONE. Calculated labels synchronously for user {}", newsletter.getId(),
+                log.info("Newsletter {} is already DONE. Calculated labels synchronously for user {}",
+                        newsletter.getId(),
                         userId);
             } else {
                 // PENDING 상태라면 저장 후 이벤트 발행
@@ -261,7 +262,8 @@ public class NewsletterService {
                     throw new CustomException(ErrorCode.NEWSLETTER_ALREADY_EXISTS);
                 }
                 Long newsletterId = newsletter.getId();
-                applicationEventPublisher.publishEvent(new NewsletterProcessRequestedEvent(newsletterId, normalizedUrl));
+                applicationEventPublisher
+                        .publishEvent(new NewsletterProcessRequestedEvent(newsletterId, normalizedUrl));
                 log.info("Newsletter event published: newsletterId={}", newsletterId);
             }
 
@@ -433,6 +435,7 @@ public class NewsletterService {
         UserNewsletter userNewsletter = userNewsletterRepository.findByIdAndUser_Id(userNewsletterId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NEWSLETTER_NOT_FOUND));
         userNewsletter.updateIsRead();
+        userNewsletterRepository.save(userNewsletter);
     }
 
     // --- Helper Methods ---

--- a/src/test/java/com/archiveat/server/domain/newsletter/service/NewsletterServiceTest.java
+++ b/src/test/java/com/archiveat/server/domain/newsletter/service/NewsletterServiceTest.java
@@ -29,144 +29,173 @@ import static org.mockito.BDDMockito.given;
 @ExtendWith(MockitoExtension.class)
 class NewsletterServiceTest {
 
-    @InjectMocks
-    private NewsletterService newsletterService;
+        @InjectMocks
+        private NewsletterService newsletterService;
 
-    @Mock
-    private UserNewsletterRepository userNewsletterRepository;
+        @Mock
+        private UserNewsletterRepository userNewsletterRepository;
 
-    @Spy
-    private ObjectMapper objectMapper;
+        @Spy
+        private ObjectMapper objectMapper;
 
-    @Test
-    @DisplayName("simpleViewUserNewsletter returns the first summary block")
-    void simpleViewUserNewsletter_ReturnsFirstSummaryBlock() throws Exception {
-        // given
-        Long userId = 1L;
-        Long userNewsletterId = 1L;
-        String summaryJson = "[{\"title\":\"Summary 1\",\"content\":\"Content 1\"}, {\"title\":\"Summary 2\",\"content\":\"Content 2\"}]";
+        @Test
+        @DisplayName("simpleViewUserNewsletter returns the first summary block")
+        void simpleViewUserNewsletter_ReturnsFirstSummaryBlock() throws Exception {
+                // given
+                Long userId = 1L;
+                Long userNewsletterId = 1L;
+                String summaryJson = "[{\"title\":\"Summary 1\",\"content\":\"Content 1\"}, {\"title\":\"Summary 2\",\"content\":\"Content 2\"}]";
 
-        Newsletter newsletter = new Newsletter(null, "http://example.com");
-        ReflectionTestUtils.setField(newsletter, "newsletterSummary", summaryJson);
-        ReflectionTestUtils.setField(newsletter, "title", "Newsletter Title");
-        ReflectionTestUtils.setField(newsletter, "category", "Category");
-        ReflectionTestUtils.setField(newsletter, "topic", "Topic");
-        ReflectionTestUtils.setField(newsletter, "thumbnailUrl", "http://thumb.url");
+                Newsletter newsletter = new Newsletter(null, "http://example.com");
+                ReflectionTestUtils.setField(newsletter, "newsletterSummary", summaryJson);
+                ReflectionTestUtils.setField(newsletter, "title", "Newsletter Title");
+                ReflectionTestUtils.setField(newsletter, "category", "Category");
+                ReflectionTestUtils.setField(newsletter, "topic", "Topic");
+                ReflectionTestUtils.setField(newsletter, "thumbnailUrl", "http://thumb.url");
 
-        UserNewsletter userNewsletter = UserNewsletter.create(null, newsletter, null, null, "Memo");
-        ReflectionTestUtils.setField(userNewsletter, "id", userNewsletterId);
-        ReflectionTestUtils.setField(userNewsletter, "depthType", DepthType.DEEP);
-        ReflectionTestUtils.setField(userNewsletter, "perspectiveType", PerspectiveType.NOW);
+                UserNewsletter userNewsletter = UserNewsletter.create(null, newsletter, null, null, "Memo");
+                ReflectionTestUtils.setField(userNewsletter, "id", userNewsletterId);
+                ReflectionTestUtils.setField(userNewsletter, "depthType", DepthType.DEEP);
+                ReflectionTestUtils.setField(userNewsletter, "perspectiveType", PerspectiveType.NOW);
 
-        given(userNewsletterRepository.findByIdAndUser_Id(userNewsletterId, userId))
-                .willReturn(Optional.of(userNewsletter));
+                given(userNewsletterRepository.findByIdAndUser_Id(userNewsletterId, userId))
+                                .willReturn(Optional.of(userNewsletter));
 
-        // when
-        SimpleViewNewsletterResponse response = newsletterService.simpleViewUserNewsletter(userId, userNewsletterId,
-                true);
+                // when
+                SimpleViewNewsletterResponse response = newsletterService.simpleViewUserNewsletter(userId,
+                                userNewsletterId,
+                                true);
 
-        // then
-        assertThat(response.newsletterSimpleSummary()).hasSize(1);
-        assertThat(response.newsletterSimpleSummary().get(0).title()).isEqualTo("Summary 1");
-        assertThat(response.newsletterSimpleSummary().get(0).content()).isEqualTo("Content 1");
-    }
+                // then
+                assertThat(response.newsletterSimpleSummary()).hasSize(1);
+                assertThat(response.newsletterSimpleSummary().get(0).title()).isEqualTo("Summary 1");
+                assertThat(response.newsletterSimpleSummary().get(0).content()).isEqualTo("Content 1");
+                assertThat(response.isRead()).isTrue();
+        }
 
-    @Test
-    @DisplayName("simpleViewUserNewsletter returns empty list when summary is empty")
-    void simpleViewUserNewsletter_ReturnsEmptyList_WhenSummaryIsEmpty() throws Exception {
-        // given
-        Long userId = 1L;
-        Long userNewsletterId = 1L;
-        String summaryJson = "[]";
+        @Test
+        @DisplayName("simpleViewUserNewsletter returns empty list when summary is empty")
+        void simpleViewUserNewsletter_ReturnsEmptyList_WhenSummaryIsEmpty() throws Exception {
+                // given
+                Long userId = 1L;
+                Long userNewsletterId = 1L;
+                String summaryJson = "[]";
 
-        Newsletter newsletter = new Newsletter(null, "http://example.com");
-        ReflectionTestUtils.setField(newsletter, "newsletterSummary", summaryJson);
-        ReflectionTestUtils.setField(newsletter, "title", "Newsletter Title");
+                Newsletter newsletter = new Newsletter(null, "http://example.com");
+                ReflectionTestUtils.setField(newsletter, "newsletterSummary", summaryJson);
+                ReflectionTestUtils.setField(newsletter, "title", "Newsletter Title");
 
-        UserNewsletter userNewsletter = UserNewsletter.create(null, newsletter, null, null, "Memo");
-        ReflectionTestUtils.setField(userNewsletter, "id", userNewsletterId);
-        ReflectionTestUtils.setField(userNewsletter, "depthType", DepthType.DEEP);
-        ReflectionTestUtils.setField(userNewsletter, "perspectiveType", PerspectiveType.NOW);
+                UserNewsletter userNewsletter = UserNewsletter.create(null, newsletter, null, null, "Memo");
+                ReflectionTestUtils.setField(userNewsletter, "id", userNewsletterId);
+                ReflectionTestUtils.setField(userNewsletter, "depthType", DepthType.DEEP);
+                ReflectionTestUtils.setField(userNewsletter, "perspectiveType", PerspectiveType.NOW);
 
-        given(userNewsletterRepository.findByIdAndUser_Id(userNewsletterId, userId))
-                .willReturn(Optional.of(userNewsletter));
+                given(userNewsletterRepository.findByIdAndUser_Id(userNewsletterId, userId))
+                                .willReturn(Optional.of(userNewsletter));
 
-        // Real ObjectMapper to test actual parsing logic
-        // ObjectMapper is not used when summary is "[]" because of the check in
-        // parseNewsletterSummary
-        // so we don't need to stub it here
+                // Real ObjectMapper to test actual parsing logic
+                // ObjectMapper is not used when summary is "[]" because of the check in
+                // parseNewsletterSummary
+                // so we don't need to stub it here
 
-        // when
-        SimpleViewNewsletterResponse response = newsletterService.simpleViewUserNewsletter(userId, userNewsletterId,
-                true);
+                // when
+                SimpleViewNewsletterResponse response = newsletterService.simpleViewUserNewsletter(userId,
+                                userNewsletterId,
+                                true);
 
-        // then
-        assertThat(response.newsletterSimpleSummary()).isEmpty();
-    }
+                // then
+                assertThat(response.newsletterSimpleSummary()).isEmpty();
+                assertThat(response.isRead()).isTrue();
+        }
 
-    @Test
-    @DisplayName("viewUserNewsletter should return personalized classification if available")
-    void viewUserNewsletter_ShouldReturnPersonalizedClassification() {
-        // given
-        Long userId = 1L;
-        Long userNewsletterId = 10L;
+        @Test
+        @DisplayName("viewUserNewsletter should return personalized classification if available")
+        void viewUserNewsletter_ShouldReturnPersonalizedClassification() {
+                // given
+                Long userId = 1L;
+                Long userNewsletterId = 10L;
 
-        UserNewsletter userNewsletter = mock(UserNewsletter.class);
-        Newsletter newsletter = mock(Newsletter.class);
-        Category userCategory = mock(Category.class);
-        Topic userTopic = mock(Topic.class);
+                UserNewsletter userNewsletter = mock(UserNewsletter.class);
+                Newsletter newsletter = mock(Newsletter.class);
+                Category userCategory = mock(Category.class);
+                Topic userTopic = mock(Topic.class);
 
-        given(userNewsletterRepository.findByIdAndUser_Id(userNewsletterId, userId))
-                .willReturn(Optional.of(userNewsletter));
-        given(userNewsletter.getNewsletter()).willReturn(newsletter);
-        given(userNewsletter.getId()).willReturn(userNewsletterId);
-        given(newsletter.getNewsletterSummary()).willReturn("[]");
+                given(userNewsletterRepository.findByIdAndUser_Id(userNewsletterId, userId))
+                                .willReturn(Optional.of(userNewsletter));
+                given(userNewsletter.getNewsletter()).willReturn(newsletter);
+                given(userNewsletter.getId()).willReturn(userNewsletterId);
+                given(newsletter.getNewsletterSummary()).willReturn("[]");
 
-        // Original metadata - Not needed as we expect them to be ignored
+                // Original metadata - Not needed as we expect them to be ignored
 
-        // User personalized metadata
-        given(userNewsletter.getCategory()).willReturn(userCategory);
-        given(userNewsletter.getTopic()).willReturn(userTopic);
-        given(userCategory.getName()).willReturn("PersonalizedCategory");
-        given(userTopic.getName()).willReturn("PersonalizedTopic");
+                // User personalized metadata
+                given(userNewsletter.getCategory()).willReturn(userCategory);
+                given(userNewsletter.getTopic()).willReturn(userTopic);
+                given(userCategory.getName()).willReturn("PersonalizedCategory");
+                given(userTopic.getName()).willReturn("PersonalizedTopic");
 
-        // when
-        ViewNewsletterResponse response = newsletterService.viewUserNewsletter(userId, userNewsletterId, false);
+                // when
+                ViewNewsletterResponse response = newsletterService.viewUserNewsletter(userId, userNewsletterId, false);
 
-        // then
-        assertThat(response.categoryName()).isEqualTo("PersonalizedCategory");
-        assertThat(response.topicName()).isEqualTo("PersonalizedTopic");
-    }
+                // then
+                assertThat(response.categoryName()).isEqualTo("PersonalizedCategory");
+                assertThat(response.topicName()).isEqualTo("PersonalizedTopic");
+                assertThat(response.isRead()).isFalse();
+        }
 
-    @Test
-    @DisplayName("viewUserNewsletter should fallback to original classification when user classification is missing")
-    void viewUserNewsletter_ShouldFallbackToOriginalClassification() {
-        // given
-        Long userId = 1L;
-        Long userNewsletterId = 11L;
+        @Test
+        @DisplayName("viewUserNewsletter should fallback to original classification when user classification is missing")
+        void viewUserNewsletter_ShouldFallbackToOriginalClassification() {
+                // given
+                Long userId = 1L;
+                Long userNewsletterId = 11L;
 
-        UserNewsletter userNewsletter = mock(UserNewsletter.class);
-        Newsletter newsletter = mock(Newsletter.class);
+                UserNewsletter userNewsletter = mock(UserNewsletter.class);
+                Newsletter newsletter = mock(Newsletter.class);
 
-        given(userNewsletterRepository.findByIdAndUser_Id(userNewsletterId, userId))
-                .willReturn(Optional.of(userNewsletter));
-        given(userNewsletter.getNewsletter()).willReturn(newsletter);
-        given(userNewsletter.getId()).willReturn(userNewsletterId);
-        given(newsletter.getNewsletterSummary()).willReturn("[]");
+                given(userNewsletterRepository.findByIdAndUser_Id(userNewsletterId, userId))
+                                .willReturn(Optional.of(userNewsletter));
+                given(userNewsletter.getNewsletter()).willReturn(newsletter);
+                given(userNewsletter.getId()).willReturn(userNewsletterId);
+                given(newsletter.getNewsletterSummary()).willReturn("[]");
 
-        // User classification is null
-        given(userNewsletter.getCategory()).willReturn(null);
-        given(userNewsletter.getTopic()).willReturn(null);
+                // User classification is null
+                given(userNewsletter.getCategory()).willReturn(null);
+                given(userNewsletter.getTopic()).willReturn(null);
 
-        // Original metadata
-        given(newsletter.getCategory()).willReturn("OriginalCategory");
-        given(newsletter.getTopic()).willReturn("OriginalTopic");
+                // Original metadata
+                given(newsletter.getCategory()).willReturn("OriginalCategory");
+                given(newsletter.getTopic()).willReturn("OriginalTopic");
 
-        // when
-        ViewNewsletterResponse response = newsletterService.viewUserNewsletter(userId, userNewsletterId, false);
+                // when
+                ViewNewsletterResponse response = newsletterService.viewUserNewsletter(userId, userNewsletterId, false);
 
-        // then
-        assertThat(response.categoryName()).isEqualTo("OriginalCategory");
-        assertThat(response.topicName()).isEqualTo("OriginalTopic");
-    }
+                // then
+                assertThat(response.categoryName()).isEqualTo("OriginalCategory");
+                assertThat(response.topicName()).isEqualTo("OriginalTopic");
+                assertThat(response.isRead()).isFalse();
+        }
+
+        @Test
+        @DisplayName("updateIsRead should update status and save userNewsletter")
+        void updateIsRead_ShouldUpdateStatusAndSave() {
+                // given
+                Long userId = 1L;
+                Long userNewsletterId = 1L;
+
+                Newsletter newsletter = new Newsletter(null, "http://example.com");
+                UserNewsletter userNewsletter = UserNewsletter.create(null, newsletter, null, null, "Memo");
+                ReflectionTestUtils.setField(userNewsletter, "id", userNewsletterId);
+                ReflectionTestUtils.setField(userNewsletter, "isRead", false);
+
+                given(userNewsletterRepository.findByIdAndUser_Id(userNewsletterId, userId))
+                                .willReturn(Optional.of(userNewsletter));
+
+                // when
+                newsletterService.updateIsRead(userId, userNewsletterId);
+
+                // then
+                assertThat(userNewsletter.isRead()).isTrue();
+                org.mockito.Mockito.verify(userNewsletterRepository).save(userNewsletter);
+        }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 뉴스레터 읽음 상태 추적 기능 추가. 사용자가 확인한 뉴스레터를 표시할 수 있으며, 상태 변경 시 자동으로 저장됩니다.

## 테스트
- 읽음 상태 관련 기능에 대한 테스트 케이스 추가 및 검증 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->