### PR TITLE
fix: Separation isRead

### DIFF
--- a/src/main/java/com/archiveat/server/domain/newsletter/controller/NewsletterController.java
+++ b/src/main/java/com/archiveat/server/domain/newsletter/controller/NewsletterController.java
@@ -28,37 +28,23 @@ public class NewsletterController {
                 return ApiResponse.ok(deleteNewsletterResponse); // 204
         }
 
-        /**
-         * AI 요약 상세 조회
-         * 
-         * @param autoMarkRead true(기본값): 컴렉션/탐색 탭에서 자동 읽음 처리, false: 홈 탭에서 버튼 클릭 시만 처리
-         */
         @GetMapping("/{userNewsletterId}")
         public ApiResponse<ViewNewsletterResponse> viewNewsletter(
                         @PathVariable Long userNewsletterId,
-                        @AuthenticationPrincipal Long userId,
-                        @RequestParam(defaultValue = "true") boolean autoMarkRead) {
+                        @AuthenticationPrincipal Long userId) {
                 ViewNewsletterResponse viewNewsletterResponse = newsletterService.viewUserNewsletter(
                                 userId,
-                                userNewsletterId,
-                                autoMarkRead);
+                                userNewsletterId);
                 return ApiResponse.ok(viewNewsletterResponse);
         }
 
-        /**
-         * Simple 상세 조회
-         * 
-         * @param autoMarkRead true(기본값): 컴렉션/탐색 탭에서 자동 읽음 처리, false: 홈 탭에서 버튼 클릭 시만 처리
-         */
         @GetMapping("/{userNewsletterId}/simple")
         public ApiResponse<SimpleViewNewsletterResponse> simpleViewNewsletter(
                         @PathVariable Long userNewsletterId,
-                        @AuthenticationPrincipal Long userId,
-                        @RequestParam(defaultValue = "true") boolean autoMarkRead) {
+                        @AuthenticationPrincipal Long userId) {
                 SimpleViewNewsletterResponse simpleViewNewsletterResponse = newsletterService.simpleViewUserNewsletter(
                                 userId,
-                                userNewsletterId,
-                                autoMarkRead);
+                                userNewsletterId);
                 return ApiResponse.ok(simpleViewNewsletterResponse);
         }
 

--- a/src/main/java/com/archiveat/server/domain/newsletter/service/NewsletterService.java
+++ b/src/main/java/com/archiveat/server/domain/newsletter/service/NewsletterService.java
@@ -90,20 +90,10 @@ public class NewsletterService {
      * 뉴스레터 AI 요약 상세 조회
      */
     @Transactional
-    public ViewNewsletterResponse viewUserNewsletter(Long userId, Long userNewsletterId, boolean autoMarkRead) {
+    public ViewNewsletterResponse viewUserNewsletter(Long userId, Long userNewsletterId) {
         UserNewsletter userNewsletter = userNewsletterRepository
                 .findByIdAndUser_Id(userNewsletterId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NEWSLETTER_NOT_FOUND));
-
-        if (autoMarkRead) {
-            if (!userNewsletter.isRead())
-                userNewsletter.updateIsRead();
-            else
-                userNewsletter.updateLastViewedAt();
-        } else {
-            userNewsletter.updateLastViewedAt();
-        }
-        userNewsletterRepository.save(userNewsletter);
 
         Newsletter newsletter = userNewsletter.getNewsletter();
         List<NewsletterSummaryBlock> summaryBlocks = parseNewsletterSummary(newsletter.getNewsletterSummary());
@@ -155,20 +145,12 @@ public class NewsletterService {
      * 뉴스레터 Simple 상세 조회
      */
     @Transactional
-    public SimpleViewNewsletterResponse simpleViewUserNewsletter(Long userId, Long userNewsletterId,
-            boolean autoMarkRead) {
+    public SimpleViewNewsletterResponse simpleViewUserNewsletter(Long userId, Long userNewsletterId) {
         UserNewsletter userNewsletter = userNewsletterRepository
                 .findByIdAndUser_Id(userNewsletterId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NEWSLETTER_NOT_FOUND));
 
-        if (autoMarkRead) {
-            if (!userNewsletter.isRead())
-                userNewsletter.updateIsRead();
-            else
-                userNewsletter.updateLastViewedAt();
-        } else {
-            userNewsletter.updateLastViewedAt();
-        }
+        userNewsletter.updateIsRead();
         userNewsletterRepository.save(userNewsletter);
 
         Newsletter newsletter = userNewsletter.getNewsletter();

--- a/src/test/java/com/archiveat/server/domain/newsletter/service/NewsletterServiceTest.java
+++ b/src/test/java/com/archiveat/server/domain/newsletter/service/NewsletterServiceTest.java
@@ -63,8 +63,7 @@ class NewsletterServiceTest {
 
                 // when
                 SimpleViewNewsletterResponse response = newsletterService.simpleViewUserNewsletter(userId,
-                                userNewsletterId,
-                                true);
+                                userNewsletterId);
 
                 // then
                 assertThat(response.newsletterSimpleSummary()).hasSize(1);
@@ -100,8 +99,7 @@ class NewsletterServiceTest {
 
                 // when
                 SimpleViewNewsletterResponse response = newsletterService.simpleViewUserNewsletter(userId,
-                                userNewsletterId,
-                                true);
+                                userNewsletterId);
 
                 // then
                 assertThat(response.newsletterSimpleSummary()).isEmpty();
@@ -135,7 +133,7 @@ class NewsletterServiceTest {
                 given(userTopic.getName()).willReturn("PersonalizedTopic");
 
                 // when
-                ViewNewsletterResponse response = newsletterService.viewUserNewsletter(userId, userNewsletterId, false);
+                ViewNewsletterResponse response = newsletterService.viewUserNewsletter(userId, userNewsletterId);
 
                 // then
                 assertThat(response.categoryName()).isEqualTo("PersonalizedCategory");
@@ -168,7 +166,7 @@ class NewsletterServiceTest {
                 given(newsletter.getTopic()).willReturn("OriginalTopic");
 
                 // when
-                ViewNewsletterResponse response = newsletterService.viewUserNewsletter(userId, userNewsletterId, false);
+                ViewNewsletterResponse response = newsletterService.viewUserNewsletter(userId, userNewsletterId);
 
                 // then
                 assertThat(response.categoryName()).isEqualTo("OriginalCategory");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 뉴스레터 조회 기능에서 선택적 파라미터를 제거하여 동작을 단순화했습니다. 뉴스레터 보기 시 일관된 읽음 상태 업데이트 처리를 적용합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->