### PR TITLE
NewsletterServiceTest 테스트함수 추가

### DIFF
--- a/src/test/java/com/archiveat/server/domain/newsletter/service/NewsletterServiceTest.java
+++ b/src/test/java/com/archiveat/server/domain/newsletter/service/NewsletterServiceTest.java
@@ -370,6 +370,7 @@ class NewsletterServiceTest {
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(newsletterSynchronizer.getOrCreateDomain(any())).willReturn(Domain.builder().name("Test").build());
         given(newsletterSynchronizer.getOrCreatePendingNewsletter(any(), eq(url))).willReturn(existingNewsletter);
+        given(userNewsletterRepository.existsByUserAndNewsletter(any(), any())).willReturn(false);
 
         // 유저 관심사 카테고리에 '기술'이 포함되어 있다고 가정 (-> NOW 라벨)
         given(userTopicRepository.findCategoryNamesByUserIdAndPerspectiveType(userId, PerspectiveType.NOW))

--- a/src/test/java/com/archiveat/server/domain/newsletter/service/NewsletterServiceTest.java
+++ b/src/test/java/com/archiveat/server/domain/newsletter/service/NewsletterServiceTest.java
@@ -2,7 +2,11 @@ package com.archiveat.server.domain.newsletter.service;
 
 import com.archiveat.server.domain.explore.entity.Category;
 import com.archiveat.server.domain.explore.entity.Topic;
+import com.archiveat.server.domain.explore.repository.TopicNewsletterRepository;
+import com.archiveat.server.domain.explore.repository.TopicRepository;
+import com.archiveat.server.domain.explore.repository.UserTopicRepository;
 import com.archiveat.server.domain.newsletter.dto.response.GenerateNewsletterResponse;
+import com.archiveat.server.domain.newsletter.dto.response.PythonSummaryResponse;
 import com.archiveat.server.domain.newsletter.dto.response.SimpleViewNewsletterResponse;
 import com.archiveat.server.domain.newsletter.dto.response.ViewNewsletterResponse;
 import com.archiveat.server.domain.newsletter.entity.Domain;
@@ -10,12 +14,16 @@ import com.archiveat.server.domain.newsletter.entity.Newsletter;
 import com.archiveat.server.domain.newsletter.entity.UserNewsletter;
 import com.archiveat.server.domain.newsletter.event.NewsletterProcessRequestedEvent;
 import com.archiveat.server.domain.newsletter.repository.DomainRepository;
+import com.archiveat.server.domain.newsletter.repository.NewsletterRepository;
 import com.archiveat.server.domain.newsletter.repository.UserNewsletterRepository;
 import com.archiveat.server.domain.user.entity.User;
 import com.archiveat.server.domain.user.repository.UserRepository;
+import com.archiveat.server.global.client.PythonClientService;
 import com.archiveat.server.global.common.constant.DepthType;
 import com.archiveat.server.global.common.constant.LlmStatus;
 import com.archiveat.server.global.common.constant.PerspectiveType;
+import com.archiveat.server.global.lock.DistributedLockService;
+import com.archiveat.server.global.security.TokenHashUtil;
 import com.archiveat.server.global.util.UrlRedirectResolver;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -25,21 +33,27 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class NewsletterServiceTest {
@@ -61,6 +75,22 @@ class NewsletterServiceTest {
     private ApplicationEventPublisher applicationEventPublisher;
     @Mock
     private TransactionTemplate transactionTemplate;
+    @Mock
+    private UserTopicRepository userTopicRepository;
+    @Mock
+    private NewsletterRepository newsletterRepository;
+    @Mock
+    private PythonClientService pythonClientService;
+    @Mock
+    private DistributedLockService distributedLockService;
+    @Mock
+    private TokenHashUtil tokenHashUtil;
+    @Mock
+    private TopicRepository topicRepository;
+    @Mock
+    private TopicNewsletterRepository topicNewsletterRepository;
+    @Mock
+    private CacheManager cacheManager;
 
     @Spy
     private ObjectMapper objectMapper;
@@ -310,5 +340,177 @@ class NewsletterServiceTest {
                         un.getNewsletter().equals(newsletter) &&
                         un.getMemo().equals(memo)
         ));
+    }
+
+    @Test
+    @DisplayName("뉴스레터 생성 성공: 이미 DONE 상태인 뉴스레터 요청 시 이벤트를 발행하지 않고 라벨을 즉시 계산한다")
+    void generateNewsletter_Success_Existing_Done() {
+        // given
+        Long userId = 1L;
+        String url = "https://already-analyzed.com";
+
+        User user = User.builder().build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        Newsletter existingNewsletter = Newsletter.builder()
+                .contentUrl(url)
+                .llmStatus(LlmStatus.DONE)
+                .build();
+
+        ReflectionTestUtils.setField(existingNewsletter, "id", 999L);
+        ReflectionTestUtils.setField(existingNewsletter, "category", "기술");
+        ReflectionTestUtils.setField(existingNewsletter, "consumptionTimeMin", 15);
+
+        given(urlRedirectResolver.resolveIfShortUrl(any())).willReturn(url);
+        given(transactionTemplate.execute(any())).willAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(null);
+        });
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(newsletterSynchronizer.getOrCreateDomain(any())).willReturn(Domain.builder().name("Test").build());
+        given(newsletterSynchronizer.getOrCreatePendingNewsletter(any(), eq(url))).willReturn(existingNewsletter);
+
+        // 유저 관심사 카테고리에 '기술'이 포함되어 있다고 가정 (-> NOW 라벨)
+        given(userTopicRepository.findCategoryNamesByUserIdAndPerspectiveType(userId, PerspectiveType.NOW))
+                .willReturn(List.of("기술"));
+
+        // when
+        GenerateNewsletterResponse response = newsletterService.generateNewsletter(userId, url, "메모");
+
+        // then
+        assertThat(response.llmStatus()).isEqualTo("DONE");
+
+        // [핵심 검증 1] 이미 DONE 상태이므로 분석 이벤트가 발행되지 않아야 함
+        verify(applicationEventPublisher, never()).publishEvent(any(NewsletterProcessRequestedEvent.class));
+
+        // [핵심 검증 2] 라벨이 즉시 계산되어 저장되었는지 확인 (15분 -> DEEP, 관심사 일치 -> NOW)
+        verify(userNewsletterRepository).save(argThat(un ->
+                un.getDepthType() == DepthType.DEEP &&
+                        un.getPerspectiveType() == PerspectiveType.NOW
+        ));
+    }
+
+    @Test
+    @DisplayName("비동기 분석 성공: 유튜브 뉴스레터 분석 요청 시 RUNNING을 거쳐 DONE 상태로 업데이트된다")
+    void processNewsletterAsync_Success_YouTube() throws Exception {
+        // given
+        Long newsletterId = 500L;
+        String contentUrl = "https://www.youtube.com/watch?v=test";
+        String lockKey = "newsletter:lock:hashed_url";
+
+        Newsletter newsletter = Newsletter.builder()
+                .contentUrl(contentUrl)
+                .llmStatus(LlmStatus.PENDING)
+                .build();
+        ReflectionTestUtils.setField(newsletter, "id", newsletterId);
+
+        given(tokenHashUtil.sha256Hex(contentUrl)).willReturn("hashed_url");
+        given(distributedLockService.tryLock(lockKey, 1)).willReturn(true);
+        given(newsletterRepository.findById(newsletterId)).willReturn(Optional.of(newsletter));
+
+        PythonSummaryResponse mockPythonResponse = createMockYouTubeResponse();
+        given(pythonClientService.requestYouTubeSummary(contentUrl))
+                .willReturn(CompletableFuture.completedFuture(mockPythonResponse));
+
+        // [Insight] executeWithoutResult는 Consumer<TransactionStatus>를 인자로 사용합니다.
+        willAnswer(invocation -> {
+            Consumer<TransactionStatus> callback = invocation.getArgument(0);
+            callback.accept(null); // status에 null을 전달하여 콜백 내부 로직을 실행시킵니다.
+            return null;
+        }).given(transactionTemplate).executeWithoutResult(any());
+
+        // [Insight] NPE 방지를 위해 CacheManager가 특정 캐시를 반환하도록 설정 (선택사항이나 권장)
+        given(cacheManager.getCache("newsletter")).willReturn(null);
+
+        Topic mockTopic = mock(Topic.class);
+        Category mockCategory = mock(Category.class);
+
+        given(mockTopic.getName()).willReturn("AI");
+        given(mockTopic.getCategory()).willReturn(mockCategory);
+        given(mockCategory.getName()).willReturn("기술");
+
+        given(topicRepository.findByNameAndCategory_Name(anyString(), anyString()))
+                .willReturn(Optional.of(mockTopic));
+
+        // when
+        newsletterService.processNewsletterAsync(newsletterId, contentUrl);
+
+        // then
+        assertThat(newsletter.getLlmStatus()).isEqualTo(LlmStatus.DONE);
+        assertThat(newsletter.getTitle()).isEqualTo("Mock YouTube Title");
+        verify(distributedLockService).unlock(lockKey);
+        verify(userNewsletterRepository).findAllByNewsletter_Id(newsletterId);
+    }
+
+    // Helper: Python 서버의 가짜 응답 생성
+    private PythonSummaryResponse createMockYouTubeResponse() {
+        // 1. Analysis 객체 생성 및 필드 주입
+        PythonSummaryResponse.Analysis analysis = new PythonSummaryResponse.Analysis();
+        ReflectionTestUtils.setField(analysis, "categoryName", "기술");
+        ReflectionTestUtils.setField(analysis, "topicName", "AI");
+        ReflectionTestUtils.setField(analysis, "smallCardSummary", "요약본");
+        ReflectionTestUtils.setField(analysis, "mediumCardSummary", "상세 요약본");
+        ReflectionTestUtils.setField(analysis, "newsletterSummary", List.of());
+
+        // 2. VideoInfo 객체 생성 및 필드 주입
+        PythonSummaryResponse.VideoInfo videoInfo = new PythonSummaryResponse.VideoInfo();
+        ReflectionTestUtils.setField(videoInfo, "title", "Mock YouTube Title");
+        ReflectionTestUtils.setField(videoInfo, "thumbnailUrl", "http://thumb.url");
+        // [Insight] DTO 필드가 Integer이므로 600.0(Double)이 아닌 600(Integer)을 넣어야 합니다.
+        ReflectionTestUtils.setField(videoInfo, "duration", 600);
+
+        // 3. 최종 Response 객체 생성 및 주입
+        PythonSummaryResponse response = new PythonSummaryResponse();
+        ReflectionTestUtils.setField(response, "analysis", analysis);
+        ReflectionTestUtils.setField(response, "videoInfo", videoInfo);
+
+        return response;
+    }
+
+    @Test
+    @DisplayName("비동기 분석 실패: AI 서버 에러 발생 시 관련 데이터가 삭제되고 락이 해제된다")
+    void processNewsletterAsync_Failure_Cleanup() throws Exception {
+        // given
+        Long newsletterId = 500L;
+        String contentUrl = "https://www.youtube.com/watch?v=fail";
+        String lockKey = "newsletter:lock:hashed_url";
+
+        Newsletter newsletter = Newsletter.builder()
+                .contentUrl(contentUrl)
+                .llmStatus(LlmStatus.PENDING)
+                .build();
+        ReflectionTestUtils.setField(newsletter, "id", newsletterId);
+
+        given(tokenHashUtil.sha256Hex(contentUrl)).willReturn("hashed_url");
+        given(distributedLockService.tryLock(lockKey, 1)).willReturn(true);
+        given(newsletterRepository.findById(newsletterId)).willReturn(Optional.of(newsletter));
+
+        // [Insight] 외부 서버 에러를 시뮬레이션하기 위해 실패하는 CompletableFuture를 설정합니다.
+        CompletableFuture<PythonSummaryResponse> future = new CompletableFuture<>();
+        future.completeExceptionally(new RuntimeException("AI Server Error"));
+        given(pythonClientService.requestYouTubeSummary(anyString()))
+                .willReturn(future);
+
+        // cleanup(markNewsletterFailed) 로직에 필요한 데이터 모킹
+        given(userNewsletterRepository.findAllByNewsletter_Id(newsletterId)).willReturn(List.of());
+        given(topicNewsletterRepository.findAllByNewsletterId(newsletterId)).willReturn(List.of());
+
+        given(cacheManager.getCache("newsletter")).willReturn(null);
+
+        // when & then
+        // 서비스 내부에서 예외를 다시 던지므로 이를 확인합니다.
+        org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+                        newsletterService.processNewsletterAsync(newsletterId, contentUrl))
+                .isInstanceOf(RuntimeException.class);
+
+        // [핵심 검증 1] 실패 시 markNewsletterFailed가 호출되어 뉴스레터가 삭제되었는지 확인
+        verify(newsletterRepository).deleteById(newsletterId);
+
+        // [핵심 검증 2] 예외가 발생하더라도 분산 락은 반드시 해제되어야 합니다.
+        verify(distributedLockService).unlock(lockKey);
+
+        // [핵심 검증 3] 실패 시 캐시 무효화가 호출되는지 확인
+        verify(cacheManager, atLeastOnce()).getCache("newsletter");
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 뉴스레터 처리 기능에 대한 테스트 커버리지 확대
  * 기존 완료된 뉴스레터 처리 경로 검증 추가(중복 이벤트 미발행, 즉시 레이블 계산)
  * YouTube 콘텐츠의 비동기 처리 흐름 검증 추가(잠금, 상태 전환, 데이터 채움)
  * 처리 실패 시 정리 및 복구 경로(삭제·잠금 해제·캐시 무효화) 검증 추가
  * 전체 시스템 안정성 및 신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->